### PR TITLE
Auto-generation of definitions library when using MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(calculate)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/")
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -std=c++11")
@@ -15,12 +15,13 @@ endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
-file(GLOB sources src/*.cpp)
-add_library(calculate_static STATIC ${sources})
-add_library(calculate SHARED ${sources})
+file(GLOB sources "src/*.cpp")
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+add_library(calculate SHARED "${sources}")
+add_library(calculate_static STATIC "${sources}")
 
-add_executable(test_c test/test.c)
+add_executable(test_c "test/test.c")
 target_link_libraries(test_c LINK_PUBLIC calculate)
 
-add_executable(test_cpp test/test.cpp)
+add_executable(test_cpp "test/test.cpp")
 target_link_libraries(test_cpp LINK_PUBLIC calculate)


### PR DESCRIPTION
Fixes #11. It wasn't necessary any change to the source code. [The solution adopted](https://bitbucket.org/vlasovmaksim/cmake_windows_export_all_symbols/overview).
