### PR TITLE
Constants refactored

### DIFF
--- a/include/symbols.h
+++ b/include/symbols.h
@@ -17,12 +17,23 @@ struct NAME : public BaseSymbolException {                                    \
     }                                                                         \
 };
 
+
 #define RECORD_CONSTANT(TOKEN, VALUE)                                         \
 class Constant_##TOKEN final : public Constant {                              \
     static const Constant::Recorder _recorder;                                \
+    static pSymbol newConstant() noexcept {                                   \
+        return pSymbol(new Constant_##TOKEN);                                 \
+    }                                                                         \
+                                                                              \
+    Constant_##TOKEN() noexcept :                                             \
+        Constant(std::to_string(VALUE)) {}                                    \
+                                                                              \
+public:                                                                       \
+    virtual double evaluate() const {return VALUE;}                           \
 };                                                                            \
 const Constant::Recorder Constant_##TOKEN::_recorder =                        \
-    Constant::Recorder(#TOKEN, VALUE);
+    Constant::Recorder(#TOKEN, &Constant_##TOKEN::newConstant);
+
 
 #define RECORD_OPERATOR(NAME, TOKEN, PRECEDENCE, L_ASSOCIATION, FUNCTION)     \
 class Operator_##NAME final : public Operator {                               \
@@ -30,8 +41,10 @@ class Operator_##NAME final : public Operator {                               \
     static pSymbol newOperator() noexcept {                                   \
         return pSymbol(new Operator_##NAME);                                  \
     }                                                                         \
+                                                                              \
     Operator_##NAME() noexcept :                                              \
         Operator(TOKEN, PRECEDENCE, L_ASSOCIATION) {}                         \
+                                                                              \
 public:                                                                       \
     virtual double evaluate() const {                                         \
         double a = _left_operand->evaluate();                                 \
@@ -42,14 +55,17 @@ public:                                                                       \
 const Operator::Recorder Operator_##NAME::_recorder =                         \
     Operator::Recorder(TOKEN, &Operator_##NAME::newOperator);
 
+
 #define RECORD_FUNCTION(TOKEN, ARGS, FUNCTION)                                \
 class Function_##TOKEN final : public Function {                              \
     static const Function::Recorder _recorder;                                \
     static pSymbol newFunction() noexcept {                                   \
         return pSymbol(new Function_##TOKEN);                                 \
     }                                                                         \
+                                                                              \
     Function_##TOKEN() noexcept :                                             \
         Function(#TOKEN, ARGS) {}                                             \
+                                                                              \
 public:                                                                       \
     virtual double evaluate() const {                                         \
         vName x(args);                                                        \
@@ -128,9 +144,9 @@ namespace symbols {
     class Constant : public Symbol {
     protected:
         struct Recorder {
-            Recorder(const String &t, double v) noexcept;
+            Recorder(const String &t, fSymbolGen g) noexcept;
         };
-        static mValue _symbols;
+        static mSymbolGen _symbols;
 
         Constant(const String &s) noexcept :
             Symbol(s, Type::CONSTANT), value(std::stod(s)) {}

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -6,7 +6,7 @@
 
 namespace symbols {
 
-    mValue Constant::_symbols;
+    mSymbolGen Constant::_symbols;
     mSymbolGen Operator::_symbols;
     String Operator::_regex_simple;
     String Operator::_regex_composite;
@@ -24,9 +24,7 @@ namespace symbols {
             }())
             return pSymbol(new Constant(t));
         else if (Constant::_symbols.find(t) != Constant::_symbols.end())
-            return pSymbol(
-                new Constant(std::to_string(Constant::_symbols[t]))
-            );
+            return Constant::_symbols[t]();
         else if (t == "(")
             return pSymbol(new Parenthesis<'('>);
         else if (t == ")")
@@ -42,8 +40,8 @@ namespace symbols {
     }
 
 
-    Constant::Recorder::Recorder(const String &t, double v) noexcept {
-        Constant::_symbols[t] = v;
+    Constant::Recorder::Recorder(const String &t, fSymbolGen g) noexcept {
+        Constant::_symbols[t] = g;
     }
 
 


### PR DESCRIPTION
Fixes #14. `Constant` subclasses rewritten as the ones of `Operator` or `Function`.
