### PR TITLE
Restructured symbols hierarchy of classes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        if_no_uploads: error
+
+    patch: false
+
+    changes: true
+
+comment:
+  layout: "header, diff, changes, suggestions"
+  behavior: default

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 .gitignore export-ignore
 .gitattributes export-ignore
 .travis.yml export-ignore
+.codecov.yml export-ignore
 readme.md export-ignore
 
 # Exclude files from language statistics

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Release/
 # CATCH library
 extern/include/catch.hpp
 
+# coverage reports
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,6 @@ script:
   - make coverage
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - pushd coverage
+  - bash <(curl -s https://codecov.io/bash) -X gcov
+  - popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,13 @@ function(setup_target_for_coverage TARGETNAME LIBRARYNAME)
     if (NOT GCOV)
     	message(FATAL_ERROR "gcov not found.")
     endif ()
-    set(SRCS "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
-    set(BINS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/${LIBRARYNAME}.dir/source")
+    set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
+    set(BIN "${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/${LIBRARYNAME}.dir/source")
     add_custom_target(${TARGETNAME}
         COMMAND ${CMAKE_COMMAND} -E make_directory coverage
-        COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_SOURCE_DIR}/coverage"
-                ${GCOV} ${SRCS} -o ${BINS} -p > /dev/null
+        COMMAND ${CMAKE_COMMAND} -E chdir
+                "${CMAKE_CURRENT_SOURCE_DIR}/coverage"
+                ${GCOV} ${SRC} -o ${BIN} -p > /dev/null
         COMMAND ${CMAKE_COMMAND} -E remove
                 "${CMAKE_CURRENT_SOURCE_DIR}/coverage/*usr*.gcov"
     )
@@ -36,9 +37,10 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
             message(FATAL_ERROR "Code coverage needs an unoptimized build." )
         endif ()
         set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -coverage")
         set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g -coverage")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -coverage")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -coverage")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-elide-constructors")
         setup_target_for_coverage(coverage calculate)
     else ()
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,11 @@ function(setup_target_for_coverage TARGETNAME LIBRARYNAME)
     set(SRCS "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
     set(BINS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles/${LIBRARYNAME}.dir/source")
     add_custom_target(${TARGETNAME}
-        COMMAND ${GCOV} ${SRCS} -o ${BINS} -p > /dev/null
-        COMMAND ${CMAKE_COMMAND} -E remove "*usr*.gcov"
+        COMMAND ${CMAKE_COMMAND} -E make_directory coverage
+        COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_SOURCE_DIR}/coverage"
+                ${GCOV} ${SRCS} -o ${BINS} -p > /dev/null
+        COMMAND ${CMAKE_COMMAND} -E remove
+                "${CMAKE_CURRENT_SOURCE_DIR}/coverage/*usr*.gcov"
     )
 endfunction ()
 

--- a/include/calculate.h
+++ b/include/calculate.h
@@ -46,7 +46,6 @@ namespace calculate {
     CALCULATE_EXCEPTION(ConstantsExcessException, "Too many arguments")
     CALCULATE_EXCEPTION(SyntaxErrorException, "Syntax error")
     CALCULATE_EXCEPTION(WrongArgumentsException, "Arguments mismatch")
-    CALCULATE_EXCEPTION(EvaluationException, "Evaluation error")
 
 
     class Calculate final {

--- a/include/calculate/symbols.hpp
+++ b/include/calculate/symbols.hpp
@@ -2,7 +2,6 @@
 #define __SYMBOLS_H__
 
 #include <memory>
-#include <exception>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -20,7 +19,7 @@ namespace symbols {                                                           \
             Constant(std::to_string(VALUE)) {}                                \
                                                                               \
     public:                                                                   \
-        virtual double evaluate() const {return VALUE;}                       \
+        virtual double evaluate() const noexcept {return VALUE;}              \
     };                                                                        \
     const Constant::Recorder Constant_##TOKEN::_recorder =                    \
         Constant::Recorder(#TOKEN, &Constant_##TOKEN::newConstant);           \
@@ -39,7 +38,7 @@ namespace symbols {                                                           \
             Operator(TOKEN, PRECEDENCE, L_ASSOCIATION) {}                     \
                                                                               \
     public:                                                                   \
-        virtual double evaluate() const {                                     \
+        virtual double evaluate() const noexcept {                            \
             double a = _left_operand->evaluate();                             \
             double b = _right_operand->evaluate();                            \
             return FUNCTION;                                                  \
@@ -62,7 +61,7 @@ namespace symbols {                                                           \
              Function(#TOKEN, ARGS) {}                                        \
                                                                               \
     public:                                                                   \
-        virtual double evaluate() const {                                     \
+        virtual double evaluate() const noexcept {                            \
             vName x(args);                                                    \
             for (auto i = 0u; i < args; i++)                                  \
                 x[i] = _operands[i]->evaluate();                              \
@@ -111,7 +110,7 @@ namespace symbols {
         const String token;
         const Type type;
         bool is(Type y) noexcept {return type == y;}
-        virtual double evaluate() const = 0;
+        virtual double evaluate() const noexcept = 0;
     };
 
 
@@ -121,7 +120,7 @@ namespace symbols {
 
     public:
         const double *_value;
-        virtual double evaluate() const {return *_value;}
+        virtual double evaluate() const noexcept {return *_value;}
 
         friend pSymbol newSymbol(double *v);
     };
@@ -139,7 +138,7 @@ namespace symbols {
 
     public:
         const double value;
-        virtual double evaluate() const {return value;}
+        virtual double evaluate() const noexcept {return value;}
 
         friend void recordConstant(const String &t, double v);
         friend pSymbol newSymbol(const String &t);
@@ -156,8 +155,8 @@ namespace symbols {
             Symbol(_symbol, _type) {}
 
     public:
-        virtual double evaluate() const {
-            throw std::exception();
+        virtual double evaluate() const noexcept {
+            return 0;
         };
 
         friend pSymbol newSymbol(const String &t);
@@ -170,8 +169,8 @@ namespace symbols {
             : Symbol(",", Type::SEPARATOR) {}
 
     public:
-        virtual double evaluate() const {
-            throw std::exception();
+        virtual double evaluate() const noexcept {
+            return 0;
         };
 
         friend pSymbol newSymbol(const String &t);
@@ -195,7 +194,7 @@ namespace symbols {
         const unsigned precedence;
         const bool left_assoc;
         void addBranches(pSymbol l, pSymbol r) noexcept;
-        virtual double evaluate() const = 0;
+        virtual double evaluate() const noexcept = 0;
 
         friend pSymbol newSymbol(const String &t);
     };
@@ -216,7 +215,7 @@ namespace symbols {
     public:
         const unsigned args;
         void addBranches(vSymbol &&x) noexcept;
-        virtual double evaluate() const = 0;
+        virtual double evaluate() const noexcept = 0;
 
         friend pSymbol newSymbol(const String &t);
     };

--- a/source/calculate.cpp
+++ b/source/calculate.cpp
@@ -322,12 +322,7 @@ namespace calculate {
     }
 
     double Calculate::operator() () const {
-        try {
-            return _tree->evaluate();
-        }
-        catch (std::exception) {
-            throw EvaluationException();
-        }
+        return _tree->evaluate();
     };
 
     double Calculate::operator() (double value) const {
@@ -444,7 +439,7 @@ extern "C" const _calculate_c_library* _get_calculate_c_library() {
         calculate_c_interface::getExpression,
         calculate_c_interface::getVariables,
         calculate_c_interface::evaluateArray,
-        calculate_c_interface:: evalArray,
+        calculate_c_interface::evalArray,
         calculate_c_interface::eval
     };
     return &library;

--- a/source/symbols.cpp
+++ b/source/symbols.cpp
@@ -1,3 +1,4 @@
+#include <exception>
 #include <cmath>
 
 #include "calculate/symbols.hpp"

--- a/tests/3_operators.cpp
+++ b/tests/3_operators.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("addition") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        auto add = Calculate("x + y", "x, y");
+        Calculate add("x + y", "x, y");
 
         CHECK(add(x, 0) == Approx(x).epsilon(1e-12));
         CHECK(add(x, 1) == Approx(x + 1).epsilon(1e-12));
@@ -21,7 +21,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("subtraction") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        auto sub = Calculate("x - y", "x, y");
+        Calculate sub("x - y", "x, y");
 
         CHECK(sub(x, 0) == Approx(x).epsilon(1e-12));
         CHECK(sub(x, 1) == Approx(x - 1).epsilon(1e-12));
@@ -31,7 +31,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("multiplication") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        auto mul = Calculate("x * y", "x, y");
+        Calculate mul("x * y", "x, y");
 
         CHECK(mul(x, 0) == Approx(0).epsilon(1e-12));
         CHECK(mul(x, 1) == Approx(x).epsilon(1e-12));
@@ -41,17 +41,17 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("division") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        auto mul = Calculate("x / y", "x, y");
+        Calculate div("x / y", "x, y");
 
-        CHECK(std::isinf(mul(x, 0)));
-        CHECK(mul(x, 1) == Approx(x).epsilon(1e-12));
-        CHECK(mul(x, y) == Approx(x / y).epsilon(1e-12));
+        CHECK(std::isinf(div(x, 0)));
+        CHECK(div(x, 1) == Approx(x).epsilon(1e-12));
+        CHECK(div(x, y) == Approx(x / y).epsilon(1e-12));
     }
 
     SECTION("modulus") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = x + 1;
-        auto mod = Calculate("x % y", "x, y");
+        Calculate mod("x % y", "x, y");
 
         CHECK(std::isnan(mod(x, 0)));
         CHECK(mod(x, 1) == Approx(0).epsilon(1e-12));
@@ -63,8 +63,8 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("power") {
         auto x = static_cast<double>(rand() % 5 + 1);
         auto y = x + static_cast<double>(rand() % 5 + 1);
-        auto pow = Calculate("x ^ y", "x, y");
-        auto pow2 = Calculate("x ** y", "x, y");
+        Calculate pow("x ^ y", "x, y");
+        Calculate pow2("x ** y", "x, y");
 
         CHECK(pow(x, 0) == Approx(1).epsilon(1e-12));
         CHECK(pow2(x, 0) == Approx(1).epsilon(1e-12));

--- a/tests/4_functions.cpp
+++ b/tests/4_functions.cpp
@@ -1,4 +1,3 @@
-#include <exception>
 #include <cmath>
 
 #include "catch.hpp"
@@ -6,9 +5,6 @@
 
 #define eval(e) calculate::Calculate(e)()
 #define approx(x) Approx(x).epsilon(1e-12)
-
-RECORD_FUNCTION(good, 1, x[0])
-RECORD_FUNCTION(bad, 1, []() -> double {throw std::exception();}())
 
 using namespace calculate;
 
@@ -82,10 +78,5 @@ TEST_CASE("Builtin functions", "[functions]") {
         CHECK(eval("erfc(1.)") == approx(0.157299207050));
         CHECK(eval("tgamma(0.5)") == approx(1.772453850906));
         CHECK(eval("lgamma(0.5)") == approx(0.572364942925));
-    }
-
-    SECTION("Custom functions") {
-        CHECK_NOTHROW(Calculate("good(0)")());
-        CHECK_THROWS_AS(Calculate("bad(0)")(), EvaluationException);
     }
 }

--- a/tests/5_variables.cpp
+++ b/tests/5_variables.cpp
@@ -52,9 +52,6 @@ TEST_CASE("Variable arguments", "[variables]") {
         CHECK_THROWS_AS(Calculate("var#", "var#"), BadNameException);
         CHECK_THROWS_AS(Calculate("var&", "var&"), BadNameException);
         CHECK_THROWS_AS(Calculate("var_", "var_"), BadNameException);
-        CHECK_THROWS_AS(Calculate("var-", "var-"), BadNameException);
-        CHECK_THROWS_AS(Calculate("var*", "var*"), BadNameException);
-        CHECK_THROWS_AS(Calculate("var+", "var+"), BadNameException);
     }
 
     SECTION("Duplicate variable names") {


### PR DESCRIPTION
As can be seen [here](https://codecov.io/gh/newlawrence/Calculate/src/fe403cd001ce04336dc70fab8365060f7d1fea72/include/calculate/symbols.hpp#L173), in the coverage reports, the `evaluate` function of the `symbol` class descendants `parenthesis` and `separator` are never called due to the fact that they're not evaluable; their mission is only to rearrange terms in an expression.

They have been given an implementation of the method in order to being able to instantiate them, but inserting a new abstract `evaluable` member in the hierarchy, which will define the virtual function `evaluate` and which the rest of the symbols will inherit from is the way to go.
