### PR TITLE
Assignment operators

### DIFF
--- a/examples/calc.cpp
+++ b/examples/calc.cpp
@@ -4,23 +4,27 @@
 
 #include "calculate.h"
 
+using namespace std;
+using namespace calculate;
+using namespace calculate_exceptions;
+
 
 int main(int argc, char *argv[]) {
     try {
         if (argc > 0 && argc % 2 == 0) {
-            auto variables = std::vector<std::string>();
-            auto values = std::vector<double>();
+            auto variables = vector<string>();
+            auto values = vector<double>();
             for (auto i = 2; i < argc; i += 2) {
                 variables.push_back(argv[i]);
-                values.push_back(std::stod(argv[i + 1]));
+                values.push_back(stod(argv[i + 1]));
             }
 
-            calculate::Calculate expression(argv[1], variables);
-            std::cout << expression(values) << std::endl;
+            auto expression = Calculate(argv[1], variables);
+            cout << expression(values) << endl;
         }
     }
-    catch (const calculate_exceptions::BaseCalculateException &e) {
-        std::cout << e.what() << std::endl;
+    catch (const BaseCalculateException &e) {
+        cout << e.what() << endl;
     }
 
     return 0;

--- a/include/calculate.h
+++ b/include/calculate.h
@@ -28,42 +28,47 @@ namespace calculate {
 
 
     class Calculate final {
+        String _expression;
+        vString _variables;
         pValue _values;
         pEvaluable _tree;
 
-        qSymbol _tokenize(const String &expression) const;
-        qSymbol _check(qSymbol &&input) const;
-        qEvaluable _shuntingYard(qSymbol &&infix) const;
-        pEvaluable _buildTree(qEvaluable &&postfix) const;
+        static qSymbol _tokenize(const String &expr, const vString &vars,
+                                 const pValue &values);
+        static qSymbol _check(qSymbol &&input);
+        static qEvaluable _shuntingYard(qSymbol &&infix);
+        static pEvaluable _buildTree(qEvaluable &&postfix);
 
         static vString _extract(const String &vars);
         static vString _validate(const vString &vars);
 
         Calculate() = delete;
-        Calculate& operator=(const Calculate &other) = delete;
-        Calculate& operator=(Calculate &&other) = delete;
 
     public:
-        const String expression;
-        const vString variables;
-
         Calculate(const Calculate &other);
         Calculate(Calculate &&other);
         Calculate(const String &expr, const String &vars);
         Calculate(const String &expr, const vString &vars={});
 
+        Calculate& operator=(const Calculate &other);
+        Calculate& operator=(Calculate &&other);
+
         bool operator==(const Calculate &other) const noexcept;
+
         double operator() () const;
         double operator() (double value) const;
         double operator() (vValue values) const;
 
         template <typename Head, typename... Tail>
         double operator() (Head head, Tail... tail) const {
-            if (sizeof...(tail) + 1 > variables.size())
+            if (sizeof...(tail) + 1 > _variables.size())
                 throw WrongArgumentsException();
-            _values[variables.size() - sizeof...(tail) - 1] = head;
+            _values[_variables.size() - sizeof...(tail) - 1] = head;
             return this->operator() (tail...);
         };
+        
+        const String& getExpression() const noexcept {return _expression;}
+        const vString& getVariables() const noexcept {return _variables;}
     };
 
 }

--- a/include/calculate/c-interface.h
+++ b/include/calculate/c-interface.h
@@ -12,6 +12,7 @@ struct calculate_c_library_template {
     Expression (*newExpression)(const char*, const char*);
     void (*freeExpression)(Expression);
 
+    int (*compare)(Expression, Expression);
     const char* (*getExpression)(Expression);
     int (*getVariables)(Expression);
 

--- a/source/c-interface.cpp
+++ b/source/c-interface.cpp
@@ -38,13 +38,13 @@ namespace calculate_c_interface {
 
     const char* getExpression(Expression expr_obj) {
         return expr_obj ?
-               static_cast<Calculate*>(expr_obj)->expression.c_str() : "";
+               static_cast<Calculate*>(expr_obj)->getExpression().c_str() : "";
     }
 
     int getVariables(Expression expr_obj) {
         return expr_obj ?
                static_cast<int>(
-                   static_cast<Calculate*>(expr_obj)->variables.size()
+                   static_cast<Calculate*>(expr_obj)->getVariables().size()
                ) : -1;
     }
 
@@ -75,7 +75,7 @@ namespace calculate_c_interface {
         if (!expr_obj)
             return std::numeric_limits<double>::quiet_NaN();
 
-        auto vars = static_cast<Calculate*>(expr_obj)->variables.size();
+        auto vars = static_cast<Calculate*>(expr_obj)->getVariables().size();
         vValue values;
         va_list list;
         va_start(list, expr_obj);

--- a/source/c-interface.cpp
+++ b/source/c-interface.cpp
@@ -36,6 +36,20 @@ namespace calculate_c_interface {
     }
 
 
+    int compare(Expression one, Expression another) {
+        if (one && another) {
+            if (
+                static_cast<Calculate *>(one)->operator==(
+                    *static_cast<Calculate *>(another)
+                )
+            )
+                return 1;
+            else
+                return 0;
+        }
+        return -1;
+    }
+
     const char* getExpression(Expression expr_obj) {
         return expr_obj ?
                static_cast<Calculate*>(expr_obj)->getExpression().c_str() : "";
@@ -93,6 +107,7 @@ extern "C" const calculate_c_library_template Calculate = {
     calculate_c_interface::createExpression,
     calculate_c_interface::newExpression,
     calculate_c_interface::freeExpression,
+    calculate_c_interface::compare,
     calculate_c_interface::getExpression,
     calculate_c_interface::getVariables,
     calculate_c_interface::evaluateArray,

--- a/tests/1_expressions.cpp
+++ b/tests/1_expressions.cpp
@@ -7,14 +7,16 @@ using namespace calculate_exceptions;
 
 TEST_CASE("Constructors test", "[Constructors]") {
 
-    SECTION("Constructors") {
-        Calculate expression1(Calculate("1 + x", "x"));
-        Calculate expression2(expression1);
-        CHECK(expression1 == expression2);
-        CHECK(
-            static_cast<int>(expression1(2)) ==
-            static_cast<int>(expression2(2))
-        );
+    SECTION("Constructors and assignments") {
+        auto expr1 = Calculate("1 + x", "x");
+        auto expr2 = expr1;
+        CHECK(expr1 == expr2);
+        CHECK(static_cast<int>(expr1(2)) == static_cast<int>(expr2(2)));
+
+        expr1 = Calculate("1 + x", "x");
+        expr2 = expr1;
+        CHECK(expr1 == expr2);
+        CHECK(static_cast<int>(expr1(2)) == static_cast<int>(expr2(2)));
     }
 
 }

--- a/tests/2_constants.cpp
+++ b/tests/2_constants.cpp
@@ -7,22 +7,22 @@ using namespace calculate;
 TEST_CASE("Builtin constants", "[constants]") {
 
     SECTION("pi") {
-        Calculate pi("pi");
+        auto pi = Calculate("pi");
         CHECK(pi() == Approx(3.141592653589).epsilon(1e-12));
     }
 
     SECTION("e") {
-        Calculate e("e");
+        auto e = Calculate("e");
         CHECK(e() == Approx(2.718281828459).epsilon(1e-12));
     }
 
     SECTION("phi") {
-        Calculate phi("phi");
+        auto phi = Calculate("phi");
         CHECK(phi() == Approx(1.618033988749).epsilon(1e-12));
     }
 
     SECTION("gamma") {
-        Calculate gamma("gamma");
+        auto gamma = Calculate("gamma");
         CHECK(gamma() == Approx(0.577215664901).epsilon(1e-12));
     }
 

--- a/tests/3_operators.cpp
+++ b/tests/3_operators.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("addition") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        Calculate add("x + y", "x, y");
+        auto add = Calculate("x + y", "x, y");
 
         CHECK(add(x, 0) == Approx(x).epsilon(1e-12));
         CHECK(add(x, 1) == Approx(x + 1).epsilon(1e-12));
@@ -21,7 +21,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("subtraction") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        Calculate sub("x - y", "x, y");
+        auto sub = Calculate("x - y", "x, y");
 
         CHECK(sub(x, 0) == Approx(x).epsilon(1e-12));
         CHECK(sub(x, 1) == Approx(x - 1).epsilon(1e-12));
@@ -31,7 +31,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("multiplication") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        Calculate mul("x * y", "x, y");
+        auto mul = Calculate("x * y", "x, y");
 
         CHECK(mul(x, 0) == Approx(0).epsilon(1e-12));
         CHECK(mul(x, 1) == Approx(x).epsilon(1e-12));
@@ -41,7 +41,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("division") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = static_cast<double>(rand() % 1000 + 1);
-        Calculate div("x / y", "x, y");
+        auto div = Calculate("x / y", "x, y");
 
         CHECK(std::isinf(div(x, 0)));
         CHECK(div(x, 1) == Approx(x).epsilon(1e-12));
@@ -51,7 +51,7 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("modulus") {
         auto x = static_cast<double>(rand() % 1000 + 1);
         auto y = x + 1;
-        Calculate mod("x % y", "x, y");
+        auto mod = Calculate("x % y", "x, y");
 
         CHECK(std::isnan(mod(x, 0)));
         CHECK(mod(x, 1) == Approx(0).epsilon(1e-12));
@@ -63,8 +63,8 @@ TEST_CASE("Builtin operators", "[operators]") {
     SECTION("power") {
         auto x = static_cast<double>(rand() % 5 + 1);
         auto y = x + static_cast<double>(rand() % 5 + 1);
-        Calculate pow("x ^ y", "x, y");
-        Calculate pow2("x ** y", "x, y");
+        auto pow = Calculate("x ^ y", "x, y");
+        auto pow2 = Calculate("x ** y", "x, y");
 
         CHECK(pow(x, 0) == Approx(1).epsilon(1e-12));
         CHECK(pow2(x, 0) == Approx(1).epsilon(1e-12));

--- a/tests/4_functions.cpp
+++ b/tests/4_functions.cpp
@@ -3,7 +3,7 @@
 #include "catch.hpp"
 #include "calculate.h"
 
-#define eval(e) calculate::Calculate(e)()
+#define eval(e) Calculate(e)()
 #define approx(x) Approx(x).epsilon(1e-12)
 
 using namespace calculate;

--- a/tests/6_c-interface.cpp
+++ b/tests/6_c-interface.cpp
@@ -10,28 +10,37 @@ extern "C" const calculate_c_library_template Calculate;
 TEST_CASE("C interface", "[c_interface]") {
 
     SECTION("Well constructed expression - No error checking") {
-        Expression expr = Calculate.newExpression("1 + x", "x");
+        Expression expr1 = Calculate.newExpression("1 + x", "x");
+        Expression expr2 = Calculate.newExpression("1 + x", "x");
+        Expression expr3 = Calculate.newExpression("2 + x", "x");
         double x = 2., *xp = &x;
 
-        CHECK(std::string(Calculate.getExpression(expr)) == "1 + x");
-        CHECK(Calculate.getVariables(expr) == 1);
-        CHECK(static_cast<int>(Calculate.eval(expr)) == 1);
-        CHECK(static_cast<int>(Calculate.eval(expr, x)) == 3);
-        CHECK(static_cast<int>(Calculate.evalArray(expr, xp, 1)) == 3);
+        CHECK(Calculate.compare(expr1, expr2) == 1);
+        CHECK(Calculate.compare(expr1, expr3) == 0);
+        CHECK(std::string(Calculate.getExpression(expr1)) == "1 + x");
+        CHECK(Calculate.getVariables(expr1) == 1);
+        CHECK(static_cast<int>(Calculate.eval(expr1)) == 1);
+        CHECK(static_cast<int>(Calculate.eval(expr1, x)) == 3);
+        CHECK(static_cast<int>(Calculate.evalArray(expr1, xp, 1)) == 3);
 
-        Calculate.freeExpression(expr);
+        Calculate.freeExpression(expr3);
+        Calculate.freeExpression(expr2);
+        Calculate.freeExpression(expr1);
     }
 
     SECTION("Bad constructed expression - No error checking") {
-        Expression expr = Calculate.newExpression("1 + x", "");
+        Expression expr1 = Calculate.newExpression("1 + x", "");
+        Expression expr2 = Calculate.newExpression("1 + x", "");
         double *xp = nullptr;
 
-        CHECK(std::string(Calculate.getExpression(expr)) == "");
-        CHECK(Calculate.getVariables(expr) == -1);
-        CHECK(std::isnan(Calculate.eval(expr, 2.)));
-        CHECK(std::isnan(Calculate.evalArray(expr, xp, 0)));
+        CHECK(Calculate.compare(expr1, expr2) == -1);
+        CHECK(std::string(Calculate.getExpression(expr1)) == "");
+        CHECK(Calculate.getVariables(expr1) == -1);
+        CHECK(std::isnan(Calculate.eval(expr1, 2.)));
+        CHECK(std::isnan(Calculate.evalArray(expr1, xp, 0)));
 
-        Calculate.freeExpression(expr);
+        Calculate.freeExpression(expr2);
+        Calculate.freeExpression(expr1);
     }
 
     SECTION("Error checking") {
@@ -48,5 +57,4 @@ TEST_CASE("C interface", "[c_interface]") {
         Calculate.evaluateArray(expr, values, 2, error);
         CHECK(std::string(error) == std::string("Arguments mismatch"));
     }
-
 }


### PR DESCRIPTION
The `Calculate` class was conceived as an inmutable object, which makes easier to follow the [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) idiom in an object such as complex to build.

The decision to have constant public properties instead of making them private was taken to avoid the use of getters, but this lead to the unimplementation of the assignment operator on both, its move and copy versions. By then, it seemed a good idea since, once created, an expression is not expected to change.

However, that makes impossible the use of good new stuff like **auto** with `Calculate` objects.
