### PR TITLE
Consistent prefixes for libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,12 @@ file(GLOB sources "${PROJECT_SOURCE_DIR}/source/*.cpp")
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 add_library(calculate SHARED "${sources}")
 target_compile_definitions(calculate PUBLIC "_CRT_SECURE_NO_WARNINGS")
+set_target_properties(calculate PROPERTIES PREFIX "lib")
 
 add_library(calculate_static STATIC "${sources}")
 target_compile_definitions(calculate_static PUBLIC "_CRT_SECURE_NO_WARNINGS")
 set_target_properties(calculate_static PROPERTIES OUTPUT_NAME "calculate")
+set_target_properties(calculate_static PROPERTIES PREFIX "lib")
 
 
 if (DEFINED ENV{TESTING} OR DEFINED ENV{COVERAGE})

--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -7,13 +7,3 @@ add_custom_target(calculate_python
             "${CMAKE_CURRENT_SOURCE_DIR}/calculate"
     DEPENDS calculate
 )
-
-if (WIN32)
-    add_custom_command(
-        TARGET calculate_python
-        POST_BUILD
-        COMMAND cmake -E rename
-                "${CMAKE_CURRENT_SOURCE_DIR}/calculate/calculate.dll"
-                "${CMAKE_CURRENT_SOURCE_DIR}/calculate/libcalculate.dll"
-    )
-endif ()


### PR DESCRIPTION
Fixes #44. The libraries now will have always the “lib” prefix no matter the platform or the compiler.
