### PR TITLE
Truly modern C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (
     (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
 )
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -std=c11")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -std=c++14")
     if (DEFINED ENV{COVERAGE})
         if (NOT(CMAKE_BUILD_TYPE STREQUAL "Debug"))
             message(FATAL_ERROR "Code coverage in an optimized build.")
@@ -58,7 +58,7 @@ if (
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
     endif ()
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Ox /sdl")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++14 /sdl")
 endif ()
 
 include_directories("${PROJECT_SOURCE_DIR}/include")

--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(calculate_python NONE)
 
-add_custom_target(calculate_python
+add_custom_target(calculate_python ALL
     COMMAND ${CMAKE_COMMAND} -E copy
             "$<TARGET_FILE:calculate>"
             "${CMAKE_CURRENT_SOURCE_DIR}/calculate"

--- a/include/calculate/symbols.hpp
+++ b/include/calculate/symbols.hpp
@@ -11,12 +11,13 @@
 namespace calculate_symbols {                                                 \
     class Constant_##TOKEN final : public Constant {                          \
         static const Constant::Recorder _recorder;                            \
+        struct key {};                                                        \
         static pSymbol newConstant() noexcept {                               \
-            return pSymbol(new Constant_##TOKEN);                             \
+            return std::make_shared<Constant_##TOKEN>(key());                 \
         }                                                                     \
-        Constant_##TOKEN() noexcept :                                         \
-                Constant(std::to_string(VALUE)) {}                            \
     public:                                                                   \
+        Constant_##TOKEN(key) noexcept :                                      \
+                Constant(Constant::key(), std::to_string(VALUE)) {}           \
         virtual ~Constant_##TOKEN() {}                                        \
         virtual double evaluate() const noexcept {return VALUE;}              \
     };                                                                        \
@@ -29,12 +30,13 @@ namespace calculate_symbols {                                                 \
 namespace calculate_symbols {                                                 \
     class Operator_##NAME final : public Operator {                           \
         static const Operator::Recorder _recorder;                            \
+        struct key {};                                                        \
         static pSymbol newOperator() noexcept {                               \
-            return pSymbol(new Operator_##NAME);                              \
+            return std::make_shared<Operator_##NAME>(key());                  \
         }                                                                     \
-        Operator_##NAME() noexcept :                                          \
-                Operator(TOKEN, PRECEDENCE, L_ASSOCIATION) {}                 \
     public:                                                                   \
+        Operator_##NAME(key) noexcept :                                       \
+                Operator(TOKEN, PRECEDENCE, L_ASSOCIATION) {}                 \
         virtual ~Operator_##NAME() {}                                         \
         virtual double evaluate() const noexcept {                            \
             double a = _left_operand->evaluate();                             \
@@ -51,12 +53,13 @@ namespace calculate_symbols {                                                 \
 namespace calculate_symbols {                                                 \
     class Function_##TOKEN final : public Function {                          \
         static const Function::Recorder _recorder;                            \
+        struct key {};                                                        \
         static pSymbol newFunction() noexcept {                               \
-            return pSymbol(new Function_##TOKEN);                             \
+            return std::make_shared<Function_##TOKEN>(key());                 \
         }                                                                     \
-        Function_##TOKEN() noexcept :                                         \
-                 Function(#TOKEN, ARGS) {}                                    \
     public:                                                                   \
+        Function_##TOKEN(key) noexcept :                                      \
+                 Function(#TOKEN, ARGS) {}                                    \
         virtual ~Function_##TOKEN() {}                                        \
         virtual double evaluate() const noexcept {                            \
             vValue x(args);                                                   \
@@ -124,11 +127,11 @@ namespace calculate_symbols {
         constexpr static const Type _type =
             s == '(' ? Type::LEFT : Type::RIGHT;
         constexpr static const char _symbol[2] = {s, '\0'};
-
-        Parenthesis() noexcept :
-                Symbol(_symbol, _type) {}
+        struct key {};
 
     public:
+        Parenthesis(key) noexcept :
+            Symbol(_symbol, _type) {}
         virtual ~Parenthesis() {}
 
         friend pSymbol newSymbol(const String &t);
@@ -137,10 +140,11 @@ namespace calculate_symbols {
 
 
     class Separator final : public Symbol {
-        Separator() noexcept :
-                Symbol(",", Type::SEPARATOR) {}
+        struct key {};
 
     public:
+        Separator(key) noexcept :
+            Symbol(",", Type::SEPARATOR) {}
         virtual ~Separator() {}
 
         friend pSymbol newSymbol(const String &t);
@@ -160,13 +164,14 @@ namespace calculate_symbols {
 
 
     class Variable final : public Evaluable {
-        Variable(double *v) noexcept :
-                Evaluable("var", Type::CONSTANT),
-                _value(v) {}
+        struct key {};
 
     public:
         const double *_value;
 
+        Variable(key, double *v) noexcept :
+            Evaluable("var", Type::CONSTANT),
+            _value(v) {}
         virtual ~Variable() {}
         virtual double evaluate() const noexcept {return *_value;}
 
@@ -180,14 +185,14 @@ namespace calculate_symbols {
             Recorder(const String &t, fSymbolGen g) noexcept;
         };
         static mSymbolGen _symbols;
-
-        Constant(const String &s) noexcept :
-                Evaluable(s, Type::CONSTANT),
-                value(std::stod(s)) {}
+        struct key {};
 
     public:
         const double value;
 
+        Constant(key, const String &s) noexcept :
+            Evaluable(s, Type::CONSTANT),
+            value(std::stod(s)) {}
         virtual ~Constant() {};
         virtual double evaluate() const noexcept {return value;}
 

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Bindings for **C**, **Fortran** and **Python**.
 ### Requirements
 
 * **CMake** *>= 3.5*, to generate the makefiles and **Visual Studio** solutions.
-* **C**/**C++** compiler, with **C++11** standard support (**GNU**, **Clang** and **MSVC** tested).
+* **C**/**C++** compiler, with **C++14** standard support (**GNU**, **Clang** and **MSVC** tested).
 * **Fortran** compiler (*optional*), with **2008** standard support (**GNU** and **Intel** tested).
 * **Python** *>= 3.5* (*optional*), along with **setuptools** and **cffi** *>=1.0* libraries.
 * **gcov** and **gcovr** tools (*optional*), for generating coverage reports.

--- a/source/calculate.cpp
+++ b/source/calculate.cpp
@@ -291,7 +291,7 @@ namespace calculate {
     Expression::Expression(const String &expr, const vString &vars) :
             _expression(expr),
             _variables(_validate(vars)),
-            _values(new double[vars.size()]) {
+            _values(std::make_unique<double[]>(vars.size())) {
 
         if (expr.length() == 0)
             throw EmptyExpressionException();

--- a/source/symbols.cpp
+++ b/source/symbols.cpp
@@ -12,7 +12,7 @@ namespace calculate_symbols {
 
 
     pSymbol newSymbol(double *v) {
-        return pSymbol(new Variable(v));
+        return std::make_shared<Variable>(Variable::key(), v);
     }
 
     pSymbol newSymbol(const String &t) {
@@ -22,20 +22,19 @@ namespace calculate_symbols {
                     std::stod(t);
                     return true;
                 }
-                catch (std::logic_error) {
-                    return false;
-                }
+                catch (std::logic_error) {}
+                return false;
             }()
         )
-            return pSymbol(new Constant(t));
+            return std::make_shared<Constant>(Constant::key(), t);
         else if (Constant::_symbols.find(t) != Constant::_symbols.end())
             return Constant::_symbols[t]();
         else if (t == "(")
-            return pSymbol(new Parenthesis<'('>);
+            return std::make_shared<Parenthesis<'('>>(Parenthesis<'('>::key());
         else if (t == ")")
-            return pSymbol(new Parenthesis<')'>);
+            return std::make_shared<Parenthesis<')'>>(Parenthesis<')'>::key());
         else if (t == ",")
-            return pSymbol(new Separator);
+            return std::make_shared<Separator>(Separator::key());
         else if (Operator::_symbols.find(t) != Operator::_symbols.end())
             return Operator::_symbols[t]();
         else if (Function::_symbols.find(t) != Function::_symbols.end())


### PR DESCRIPTION
Inspired by a magnificent talk from @mmatrosov, [**C++** without new and delete](https://www.youtube.com/watch?v=N0Tj2bDxQGo), I've audited my own code to make it 100% modern **C++**.

While I've already got rid of `delete` thanks to the [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) idiom, there was another keyword left leaving my code still tied to the past: `new`. `new` needed to be replaced using the new `make_shared` (**C++11**) and `make_unique` (**C++14**) functions but, why?

As Mikhail exposes in his talk, these are the advantages of `make_shared` vs `new`:
- Exception safe (didn't matter in this case since all the constructors are `noexcept`).
- No type name duplication (good to follow the [DRI](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle).
- Symmetry (what I like the most).
- Single memory allocation (better performance in the case of `make_shared`).

The fix is very straightforward but a tiny issue, `make_shared` doesn't works with private or protected constructors (which is very common in libraries like this, that creates instances on the fly using a factory function that returns references to them). Hopefully, [this trick](http://rienajouter.blogspot.com.es/2014/10/makeshared-and-makeunique-for-classes.html) saved the day.

Instead of a private constructor, a default one is used with the addition that it needs a dummy key argument which is an empty instance of a nested class defined on the private part ([check it](https://github.com/newlawrence/Calculate/blob/94bf7dce5976bbc5e5f563f5e78595eb8380d7ce/include/calculate/symbols.hpp#L143)). Therefore, only class members or friends can actually use the constructor.
