### PR TITLE
Allow public construction of symbols

### DIFF
--- a/include/calculate/symbols.hpp
+++ b/include/calculate/symbols.hpp
@@ -11,15 +11,14 @@
 namespace calculate_symbols {                                                 \
     class Constant_##TOKEN final : public Constant {                          \
         static const Constant::Recorder _recorder;                            \
-        struct key {};                                                        \
         static pSymbol newConstant() noexcept {                               \
-            return std::make_shared<Constant_##TOKEN>(key());                 \
+            return std::make_shared<Constant_##TOKEN>();                      \
         }                                                                     \
     public:                                                                   \
-        Constant_##TOKEN(key) noexcept :                                      \
-                Constant(Constant::key(), std::to_string(VALUE)) {}           \
+        Constant_##TOKEN() noexcept :                                         \
+                Constant(std::to_string(VALUE)) {}                            \
         virtual ~Constant_##TOKEN() {}                                        \
-        virtual double evaluate() const noexcept {return VALUE;}              \
+        virtual double evaluate() const noexcept { return VALUE; }            \
     };                                                                        \
     const Constant::Recorder Constant_##TOKEN::_recorder =                    \
         Constant::Recorder(#TOKEN, &Constant_##TOKEN::newConstant);           \
@@ -30,12 +29,11 @@ namespace calculate_symbols {                                                 \
 namespace calculate_symbols {                                                 \
     class Operator_##NAME final : public Operator {                           \
         static const Operator::Recorder _recorder;                            \
-        struct key {};                                                        \
         static pSymbol newOperator() noexcept {                               \
-            return std::make_shared<Operator_##NAME>(key());                  \
+            return std::make_shared<Operator_##NAME>();                       \
         }                                                                     \
     public:                                                                   \
-        Operator_##NAME(key) noexcept :                                       \
+        Operator_##NAME() noexcept :                                          \
                 Operator(TOKEN, PRECEDENCE, L_ASSOCIATION) {}                 \
         virtual ~Operator_##NAME() {}                                         \
         virtual double evaluate() const noexcept {                            \
@@ -53,12 +51,11 @@ namespace calculate_symbols {                                                 \
 namespace calculate_symbols {                                                 \
     class Function_##TOKEN final : public Function {                          \
         static const Function::Recorder _recorder;                            \
-        struct key {};                                                        \
         static pSymbol newFunction() noexcept {                               \
-            return std::make_shared<Function_##TOKEN>(key());                 \
+            return std::make_shared<Function_##TOKEN>();                      \
         }                                                                     \
     public:                                                                   \
-        Function_##TOKEN(key) noexcept :                                      \
+        Function_##TOKEN() noexcept :                                         \
                  Function(#TOKEN, ARGS) {}                                    \
         virtual ~Function_##TOKEN() {}                                        \
         virtual double evaluate() const noexcept {                            \
@@ -106,6 +103,7 @@ namespace calculate_symbols {
         Symbol(const Symbol&) = delete;
         Symbol(Symbol&&) = delete;
         Symbol& operator=(const Symbol&) = delete;
+        Symbol& operator=(Symbol&&) = delete;
 
     protected:
         Symbol(const String &t, Type y) noexcept :
@@ -117,7 +115,7 @@ namespace calculate_symbols {
         const Type type;
 
         virtual ~Symbol() = 0;
-        bool is(Type y) const noexcept {return type == y;}
+        bool is(Type y) const noexcept { return type == y; }
     };
     inline Symbol::~Symbol() {}
 
@@ -127,27 +125,20 @@ namespace calculate_symbols {
         constexpr static const Type _type =
             s == '(' ? Type::LEFT : Type::RIGHT;
         constexpr static const char _symbol[2] = {s, '\0'};
-        struct key {};
 
     public:
-        Parenthesis(key) noexcept :
+        Parenthesis() noexcept :
             Symbol(_symbol, _type) {}
         virtual ~Parenthesis() {}
-
-        friend pSymbol newSymbol(const String &t);
     };
     template<char s> constexpr const char Parenthesis<s>::_symbol[2];
 
 
     class Separator final : public Symbol {
-        struct key {};
-
     public:
-        Separator(key) noexcept :
+        Separator() noexcept :
             Symbol(",", Type::SEPARATOR) {}
         virtual ~Separator() {}
-
-        friend pSymbol newSymbol(const String &t);
     };
 
 
@@ -164,18 +155,14 @@ namespace calculate_symbols {
 
 
     class Variable final : public Evaluable {
-        struct key {};
-
     public:
         const double *_value;
 
-        Variable(key, double *v) noexcept :
+        Variable(double *v) noexcept :
             Evaluable("var", Type::CONSTANT),
             _value(v) {}
         virtual ~Variable() {}
-        virtual double evaluate() const noexcept {return *_value;}
-
-        friend pSymbol newSymbol(double *v);
+        virtual double evaluate() const noexcept { return *_value; }
     };
 
 
@@ -185,18 +172,16 @@ namespace calculate_symbols {
             Recorder(const String &t, fSymbolGen g) noexcept;
         };
         static mSymbolGen _symbols;
-        struct key {};
 
     public:
         const double value;
 
-        Constant(key, const String &s) noexcept :
+        Constant(const String &s) noexcept :
             Evaluable(s, Type::CONSTANT),
             value(std::stod(s)) {}
         virtual ~Constant() {};
-        virtual double evaluate() const noexcept {return value;}
+        virtual double evaluate() const noexcept { return value; }
 
-        friend void recordConstant(const String &t, double v);
         friend pSymbol newSymbol(const String &t);
     };
 

--- a/source/calculate.cpp
+++ b/source/calculate.cpp
@@ -232,7 +232,7 @@ namespace calculate {
             std::remove_if(
                 no_spaces.begin(),
                 no_spaces.end(),
-                [](char c) {return c == ' ';}
+                [](char c) { return c == ' '; }
             ),
             no_spaces.end()
         );
@@ -254,7 +254,7 @@ namespace calculate {
             !std::all_of(
                 vars.begin(),
                 vars.end(),
-                [&regex](String var) {return std::regex_match(var, regex);}
+                [&regex](String var) { return std::regex_match(var, regex); }
             )
         )
             throw BadNameException();

--- a/source/symbols.cpp
+++ b/source/symbols.cpp
@@ -12,7 +12,7 @@ namespace calculate_symbols {
 
 
     pSymbol newSymbol(double *v) {
-        return std::make_shared<Variable>(Variable::key(), v);
+        return std::make_shared<Variable>(v);
     }
 
     pSymbol newSymbol(const String &t) {
@@ -26,15 +26,15 @@ namespace calculate_symbols {
                 return false;
             }()
         )
-            return std::make_shared<Constant>(Constant::key(), t);
+            return std::make_shared<Constant>(t);
         else if (Constant::_symbols.find(t) != Constant::_symbols.end())
             return Constant::_symbols[t]();
         else if (t == "(")
-            return std::make_shared<Parenthesis<'('>>(Parenthesis<'('>::key());
+            return std::make_shared<Parenthesis<'('>>();
         else if (t == ")")
-            return std::make_shared<Parenthesis<')'>>(Parenthesis<')'>::key());
+            return std::make_shared<Parenthesis<')'>>();
         else if (t == ",")
-            return std::make_shared<Separator>(Separator::key());
+            return std::make_shared<Separator>();
         else if (Operator::_symbols.find(t) != Operator::_symbols.end())
             return Operator::_symbols[t]();
         else if (Function::_symbols.find(t) != Function::_symbols.end())


### PR DESCRIPTION
Reading about the topic of the impossibility of using `make_shared` with private and protected constructors, [here](http://ideone.com/eCrNti) is another solution (referenced from [this post](http://talesofcpp.fusionfenix.com/post-5/true-story-when-friendship-smothers)) rather than the idiom of the private nested key classes. However, the solution of guarding classes will interfere later with the dynamic casts inside the `Calculate` class, and represent a little extra overhead.

Given that the risks of allowing the construction of single symbols are null, as they don't reserve or free memory, they can't even be copied or moved and the key idiom is kinda ugly, I've decided to removed them.
