### PR TITLE
Fixed Python version for conda packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(calculate C CXX)
+
+
 set(MAJOR_VERSION 1)
 set(MINOR_VERSION 1)
 set(PATCH_VERSION 1)
 set(DEV )
-set(BUILD_NUMBER 1)
-
+set(BUILD_NUMBER 0)
 set(PACKAGE_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}${DEV}")
 string(TIMESTAMP COMPILE_DATE %Y/%m/%d)
 

--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(calculate_python_wrapper NONE)
+set(PYTHON_SUPPORTED_VERSIONS 2.7 3.3 3.4 3.5 3.6)
 
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
@@ -7,23 +8,25 @@ add_library(calculate_python SHARED "${sources}")
 target_compile_definitions(calculate_python PUBLIC "_CRT_SECURE_NO_WARNINGS")
 set_target_properties(calculate_python PROPERTIES PREFIX "lib")
 
-if(UNIX AND NOT APPLE)
-    target_link_libraries(calculate_python PUBLIC
-        -static-libgcc -static-libstdc++
-    )
-elseif(WIN32)
-    if(
-        (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR
-        (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    )
+if(DEFINED ENV{NORUNTIME})
+    if(UNIX AND NOT APPLE)
         target_link_libraries(calculate_python PUBLIC
             -static-libgcc -static-libstdc++
-            -Wl,-Bstatic -lstdc++ -lpthread
-            -Wl,-Bdynamic
         )
-    elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+    elseif(WIN32)
+        if(
+            (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR
+            (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        )
+            target_link_libraries(calculate_python PUBLIC
+                -static-libgcc -static-libstdc++
+                -Wl,-Bstatic -lstdc++ -lpthread
+                -Wl,-Bdynamic
+            )
+        elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
+            set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+            set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+        endif()
     endif()
 endif()
 
@@ -70,10 +73,15 @@ if(PYTHON)
         )
         string(STRIP ${CONDA_VER} CONDA_VER)
         message("-- The Conda package manager specification is ${CONDA_VER}")
-    
-        add_custom_target(conda_package
-            DEPENDS calculate_python
-            COMMAND ${CONDA} build ${CMAKE_CURRENT_SOURCE_DIR}/recipe
-        )
+
+        foreach(PYTHON_VERSION ${PYTHON_SUPPORTED_VERSIONS})
+            add_custom_target(conda_package-Py${PYTHON_VERSION}
+                DEPENDS calculate_python
+                COMMAND ${CONDA} build purge
+                COMMAND ${CONDA} build --python=${PYTHON_VERSION}
+                        ${CMAKE_CURRENT_SOURCE_DIR}/recipe
+                COMMAND ${CONDA} build purge
+            )
+        endforeach()
     endif()
 endif()

--- a/binding/python/recipe/bld.bat
+++ b/binding/python/recipe/bld.bat
@@ -1,2 +1,0 @@
-%PYTHON% setup.py install
-IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%

--- a/binding/python/recipe/build.sh
+++ b/binding/python/recipe/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-$PYTHON setup.py install

--- a/binding/python/recipe/meta.yaml.in
+++ b/binding/python/recipe/meta.yaml.in
@@ -4,16 +4,17 @@ package:
 
 build:
   number: ${BUILD_NUMBER}
+  script: python setup.py install
 
 source:
   path: ..
 
 requirements:
   build:
-    - python >=2.7
+    - python
     - cffi >=1.0.0
   run:
-    - python >=2.7
+    - python
     - cffi >=1.0.0
 
 about:

--- a/binding/python/setup.py
+++ b/binding/python/setup.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import sys
 import os.path as path
 from platform import system
 from setuptools import setup
 
+if sys.version_info < (2, 7):
+    sys.exit('Only Python versions superior or equal than 2.7 supported')
 
 library = 'calculate'
 with open('{}/__init__.py'.format(library), 'r') as file:

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Generating the **Python** binary distributions:
 ```
 $ BINDING=1 cmake . -DCMAKE_BUILD_TYPE=Release
 $ make python_wheel
-$ make conda_package
+$ make conda_package-Py2.7
 
 ```
 


### PR DESCRIPTION
Fixes #64. The solution adopted is to build each **conda** package against its respective **Python** version.