### PR TITLE
feature/iterables

### DIFF
--- a/example/calculate.cpp
+++ b/example/calculate.cpp
@@ -95,6 +95,7 @@ void run(
     const po::variables_map& arguments
 ) {
     using Type = typename Parser::Type;
+
     Parser parser{};
 
     std::chrono::steady_clock::time_point begin;
@@ -114,8 +115,8 @@ void run(
     }
 
     auto parse = arguments.count("postfix") ?
-        &Parser::from_postfix :
-        &Parser::from_infix;
+        &Parser::template from_postfix<const std::vector<std::string>&> :
+        &Parser::template from_infix<const std::vector<std::string>&>;
 
     auto function = (parser.*parse)(expression, variables);
     if (arguments.count("analysis")) {

--- a/include/calculate.hpp
+++ b/include/calculate.hpp
@@ -136,7 +136,7 @@ public:
             return static_cast<Type>(std::norm(z));
         };
         auto polar = [](const Type& z1, const Type& z2) noexcept {
-            return z1 * std::exp(1i * z2);
+            return z1 * std::exp(1.i * z2);
         };
 
         auto add = [](const Type& z1, const Type& z2) noexcept {

--- a/include/calculate/exception.hpp
+++ b/include/calculate/exception.hpp
@@ -8,7 +8,7 @@
 namespace calculate {
 
 struct BaseError : public std::runtime_error {
-    BaseError(std::string what) : runtime_error{std::move(what)} {}
+    explicit BaseError(std::string what) : runtime_error{std::move(what)} {}
     BaseError() :
             runtime_error{std::string{"Base error: unexpected error"}}
     {}
@@ -16,7 +16,7 @@ struct BaseError : public std::runtime_error {
 
 
 struct BadCast : BaseError {
-    BadCast(const std::string& token) :
+    explicit BadCast(const std::string& token) :
             BaseError{
                 "Bad cast: cannot perform numeric conversion: '" + token + "'"
             }
@@ -56,7 +56,7 @@ struct ParenthesisMismatch : BaseError {
 
 struct RepeatedSymbol : BaseError {
     const std::string token;
-    RepeatedSymbol(const std::string& t) :
+    explicit RepeatedSymbol(const std::string& t) :
             BaseError{"Repeated symbol: '" + t + "'"},
             token{t}
     {}
@@ -64,12 +64,14 @@ struct RepeatedSymbol : BaseError {
 
 struct SyntaxError : BaseError {
     SyntaxError() : BaseError{"Syntax error"} {}
-    SyntaxError(const std::string& what) : BaseError{"Syntax error: " + what} {}
+    explicit SyntaxError(const std::string& what) :
+            BaseError{"Syntax error: " + what}
+    {}
 };
 
 struct UndefinedSymbol : BaseError {
     const std::string token;
-    UndefinedSymbol(const std::string& t) :
+    explicit UndefinedSymbol(const std::string& t) :
             BaseError{"Undefined symbol: '" + t + "'"},
             token{t}
     {}
@@ -77,7 +79,7 @@ struct UndefinedSymbol : BaseError {
 
 struct UnsuitableName : BaseError {
     const std::string token;
-    UnsuitableName(const std::string& t) :
+    explicit UnsuitableName(const std::string& t) :
             BaseError{"Unsuitable symbol name: '" + t + "'"},
             token{t}
     {}
@@ -85,7 +87,7 @@ struct UnsuitableName : BaseError {
 
 struct UnusedSymbol : BaseError {
     const std::string token;
-    UnusedSymbol(const std::string& t) :
+    explicit UnusedSymbol(const std::string& t) :
             BaseError{"Unused symbol: '" + t + "'"}, token{t}
     {}
 };

--- a/include/calculate/node.hpp
+++ b/include/calculate/node.hpp
@@ -104,7 +104,7 @@ public:
         }
 
         template<typename Args>
-        std::enable_if_t<util::is_iterable<Args>::value> update(Args&& vals) {
+        std::enable_if_t<util::Check<Args>::iterable> update(Args&& vals) {
             std::size_t i{};
 
             for (auto val = std::begin(vals); val != std::end(vals); ++val) {
@@ -117,7 +117,7 @@ public:
         }
 
         template<typename Arg>
-        std::enable_if_t<!util::is_iterable<Arg>::value> update(Arg&& val) {
+        std::enable_if_t<!util::Check<Arg>::iterable> update(Arg&& val) {
             if (_size != 1)
                 throw ArgumentsMismatch{_size, 1};
             _values[0] = val;

--- a/include/calculate/node.hpp
+++ b/include/calculate/node.hpp
@@ -163,11 +163,25 @@ private:
             };
     }
 
+    std::vector<std::string> _pruned() const noexcept {
+        std::istringstream extractor{postfix()};
+        std::vector<std::string> tokens{
+            std::istream_iterator<std::string>{extractor},
+            std::istream_iterator<std::string>{}
+        };
+        std::vector<std::string> pruned{};
+
+        for (const auto& var : _variables->variables)
+            if (std::find(tokens.begin(), tokens.end(), var) != tokens.end())
+                pruned.push_back(var);
+        return pruned;
+    }
+
 
 public:
     Node(const Node& other) noexcept :
             _lexer{other._lexer},
-            _variables{other._variables->rebuild(other.variables())},
+            _variables{other._variables->rebuild(other._pruned())},
             _token{other._token},
             _symbol{nullptr},
             _nodes{other._nodes},
@@ -341,17 +355,7 @@ public:
     }
 
     std::vector<std::string> variables() const noexcept {
-        std::istringstream extractor{postfix()};
-        std::vector<std::string> tokens{
-            std::istream_iterator<std::string>{extractor},
-            std::istream_iterator<std::string>{}
-        };
-        std::vector<std::string> pruned{};
-
-        for (const auto& var : _variables->variables)
-            if (std::find(tokens.begin(), tokens.end(), var) != tokens.end())
-                pruned.push_back(var);
-        return pruned;
+        return _variables->variables;
     }
 };
 

--- a/include/calculate/node.hpp
+++ b/include/calculate/node.hpp
@@ -7,7 +7,6 @@
 #include <sstream>
 
 #include "symbol.hpp"
-#include "util.hpp"
 
 
 namespace calculate {

--- a/include/calculate/node.hpp
+++ b/include/calculate/node.hpp
@@ -103,18 +103,31 @@ public:
             return _values[index(token)];
         }
 
-        void update(const std::vector<Type>& values) {
-            if (_size != values.size())
-                throw ArgumentsMismatch{_size, values.size()};
-            for (std::size_t i = 0; i < _size; i++)
-                _values[i] = values[i];
+        template<typename Args>
+        std::enable_if_t<util::is_iterable<Args>::value> update(Args&& vals) {
+            std::size_t i{};
+
+            for (auto val = std::begin(vals); val != std::end(vals); ++val) {
+                if (i < _size)
+                    _values[i] = *val;
+                ++i;
+            }
+            if (_size != i)
+                throw ArgumentsMismatch{_size, i};
+        }
+
+        template<typename Arg>
+        std::enable_if_t<!util::is_iterable<Arg>::value> update(Arg&& val) {
+            if (_size != 1)
+                throw ArgumentsMismatch{_size, 1};
+            _values[0] = val;
         }
 
         template<typename... Args>
-        void update(Args... args) {
-            if (_size != sizeof...(args))
-                throw ArgumentsMismatch{_size, sizeof...(args)};
-            _update(0, args...);
+        std::enable_if_t<sizeof...(Args) != 1> update(Args&&... vals) {
+            if (_size != sizeof...(vals))
+                throw ArgumentsMismatch{_size, sizeof...(vals)};
+            _update(0, vals...);
         }
     };
 

--- a/include/calculate/parser.hpp
+++ b/include/calculate/parser.hpp
@@ -505,34 +505,36 @@ public:
         return _lexer->to_string(value);
     }
 
-    Expression from_infix(
-        const std::string& expression,
-        const std::vector<std::string>& variables={}
-    ) const {
-        auto context = std::make_shared<VariableHandler>(variables, *_lexer);
-        return _build_tree(
-            _shunting_yard(_parse_infix(_tokenize(expression, context))),
-            context
+    template<typename... Args>
+    Expression from_infix(const std::string& expr, Args&&... vars) const {
+        auto variables = std::make_shared<VariableHandler>(
+            util::to_vector<std::string>(std::forward<Args>(vars)...),
+            *_lexer
         );
+        auto postfix = _shunting_yard(_parse_infix(_tokenize(expr, variables)));
+
+        return _build_tree(std::move(postfix), variables);
     }
 
-    Expression from_postfix(
-        const std::string& expression,
-        const std::vector<std::string>& variables={}
-    ) const {
-        auto context = std::make_shared<VariableHandler>(variables, *_lexer);
-        return _build_tree(_tokenize(expression, context), context);
+    template<typename... Args>
+    Expression from_postfix(const std::string& expr, Args&&... vars) const {
+        auto variables = std::make_shared<VariableHandler>(
+            util::to_vector<std::string>(std::forward<Args>(vars)...),
+            *_lexer
+        );
+
+        return _build_tree(_tokenize(expr, variables), variables);
     }
 
     Expression parse(const std::string& expression) const {
-        std::vector<std::string> variables{};
+        std::vector<std::string> vars{};
 
         while (true) {
             try {
-                return from_infix(expression, variables);
+                return from_infix(expression, vars);
             }
             catch (const UndefinedSymbol& exception) {
-                variables.emplace_back(exception.token);
+                vars.emplace_back(exception.token);
             }
             catch (const UnsuitableName& exception) {
                 throw UndefinedSymbol{exception.token};
@@ -541,16 +543,18 @@ public:
     }
 
     Expression optimize(const Expression& node) const noexcept {
-        auto variables = node.variables();
-        if (variables.empty())
+        auto vars = node.variables();
+        if (vars.empty())
             return from_infix(to_string(Type{from_postfix(node.postfix())}));
 
         auto postfix = std::string{};
-        auto context =
-            std::make_shared<VariableHandler>(std::move(variables), *_lexer);
+        auto variables =
+            std::make_shared<VariableHandler>(std::move(vars), *_lexer);
         for (const auto& branch : node._nodes)
             postfix += optimize(branch).postfix() + " ";
-        return _build_tree(_tokenize(postfix + node.token(), context), context);
+        postfix += node.token();
+
+        return _build_tree(_tokenize(postfix, variables), variables);
     }
 };
 

--- a/include/calculate/parser.hpp
+++ b/include/calculate/parser.hpp
@@ -212,10 +212,10 @@ private:
                 if (!automatic.empty() && !automatic.top())
                     automatic.pop();
 
-            collected.push(std::move(current));
             if (original)
-                parsed += current.token;
-            previous = {collected.back().token, collected.back().type, nullptr};
+                parsed += current.token + " ";
+            previous = {current.token, current.type, nullptr};
+            collected.push(std::move(current));
         };
 
         if (symbols.size() == 0)
@@ -239,7 +239,7 @@ private:
                         case (SymbolType::LEFT):
                         case (SymbolType::SEPARATOR):
                         case (SymbolType::OPERATOR):
-                            parsed += current.token;
+                            parsed += current.token + " ";
                             current = {
                                 cop->alias(),
                                 SymbolType::FUNCTION,
@@ -266,11 +266,11 @@ private:
                 throw SyntaxError{};
         }
         catch (const SyntaxError&) {
-            parsed += " '" + current.token + "' ";
+            parsed +=" '" + current.token + "' ";
             while (!symbols.empty()) {
                 current = std::move(symbols.front());
                 symbols.pop();
-                parsed += current.token;
+                parsed += current.token + " ";
             }
             throw SyntaxError{parsed};
         }

--- a/include/calculate/parser.hpp
+++ b/include/calculate/parser.hpp
@@ -543,7 +543,7 @@ public:
     }
 
     Expression optimize(const Expression& node) const noexcept {
-        auto vars = node.variables();
+        auto vars = node._pruned();
         if (vars.empty())
             return from_infix(to_string(Type{from_postfix(node.postfix())}));
 

--- a/include/calculate/util.hpp
+++ b/include/calculate/util.hpp
@@ -19,30 +19,32 @@ namespace detail {
     using std::end;
 
     template<typename Type>
-    auto check_iterable(int) -> decltype (
+    static constexpr decltype(
         begin(std::declval<Type&>()) != end(std::declval<Type&>()),
         ++std::declval<decltype(begin(std::declval<Type&>()))&>(),
         *begin(std::declval<Type&>()),
-        std::true_type{}
-    );
+        bool{}
+    ) is_iterable(int) { return true; }
 
     template<typename Type>
-    std::false_type check_iterable(...);
+    static constexpr bool is_iterable(...) { return false; }
 
 }
 
 template<typename Type>
-using is_iterable = decltype(detail::check_iterable<Type>(0));
+struct Check {
+    static constexpr bool iterable = detail::is_iterable<Type>(0);
+};
 
 
 template<typename Type, typename Args>
-std::enable_if_t<is_iterable<Args>::value, std::vector<Type>>
+std::enable_if_t<Check<Args>::iterable, std::vector<Type>>
 to_vector(Args&& args) {
     return std::vector<Type>{std::begin(args), std::end(args)};
 }
 
 template<typename Type, typename Arg>
-std::enable_if_t<!is_iterable<Arg>::value, std::vector<Type>>
+std::enable_if_t<!Check<Arg>::iterable, std::vector<Type>>
 to_vector(Arg&& arg) {
     return std::vector<Type>{std::forward<Arg>(arg)};
 }

--- a/include/calculate/wrapper.hpp
+++ b/include/calculate/wrapper.hpp
@@ -159,16 +159,16 @@ struct NotSame {
 template<typename Type, std::size_t>
 using ExtractType = Type;
 
-template<typename, std::size_t argcount, typename = std::make_index_sequence<argcount>>
+template<typename, std::size_t argc, typename = std::make_index_sequence<argc>>
 struct Repeat {};
 
-template<typename Type, std::size_t argcount, std::size_t... indices>
-struct Repeat<Type, argcount, std::index_sequence<indices...>> {
+template<typename Type, std::size_t argc, std::size_t... indices>
+struct Repeat<Type, argc, std::index_sequence<indices...>> {
     using type = std::tuple<ExtractType<Type, indices>...>;
 };
 
-template<typename Type, std::size_t argcount>
-using Repeated = typename Repeat<Type, argcount>::type;
+template<typename Type, std::size_t argc>
+using Repeated = typename Repeat<Type, argc>::type;
 
 }
 
@@ -176,7 +176,7 @@ using Repeated = typename Repeat<Type, argcount>::type;
 template<typename Type, typename Source>
 struct WrapperConcept {
     virtual ~WrapperConcept() = default;
-    virtual std::shared_ptr<WrapperConcept> copy() const noexcept = 0;
+    virtual std::shared_ptr<WrapperConcept> clone() const noexcept = 0;
     virtual std::size_t argc() const noexcept = 0;
     virtual Type call(const std::vector<Type>&) const = 0;
     virtual Type eval(const std::vector<Source>&) const = 0;
@@ -233,7 +233,7 @@ class Wrapper {
                 _adapter{adapter}
         {}
 
-        std::shared_ptr<WrapperConcept> copy() const noexcept override {
+        std::shared_ptr<WrapperConcept> clone() const noexcept override {
             return std::make_shared<WrapperModel>(*this);
         }
 
@@ -338,7 +338,7 @@ public:
             }
     {}
 
-    Wrapper copy() const noexcept { return Wrapper{_callable->copy()}; }
+    Wrapper clone() const noexcept { return Wrapper{_callable->clone()}; }
 
     std::size_t argc() const noexcept { return _callable->argc(); }
 

--- a/include/calculate/wrapper.hpp
+++ b/include/calculate/wrapper.hpp
@@ -343,7 +343,8 @@ public:
 
     template<typename... Args>
     Type operator()(Args&&... args) const {
-        return _callable->call(std::vector<Type>{std::forward<Args>(args)...});
+        return _callable
+            ->call(util::to_vector<Type>(std::forward<Args>(args)...));
     }
 
     bool operator==(const Wrapper& other) const noexcept {

--- a/include/calculate/wrapper.hpp
+++ b/include/calculate/wrapper.hpp
@@ -1,13 +1,12 @@
 #ifndef __CALCULATE_WRAPPER_HPP__
 #define __CALCULATE_WRAPPER_HPP__
 
-#include <memory>
 #include <type_traits>
 #include <tuple>
 #include <vector>
 #include <utility>
 
-#include "exception.hpp"
+#include "util.hpp"
 
 
 namespace calculate {


### PR DESCRIPTION
This pull request make all the **API** methods that accepted variadic arguments or arguments wrapped inside a vector to abstract the underlying container of the arguments. Any **C++** container that follows the **STL** of **begin** and **end** iterators can be used with the aforementioned methods:
* `Parser::from_infix`
* `Parser::from_postfix`
* `Expression::operator()`
* `Symbol::operator()`

The containers are forward traversed from begin to end due to the importance of the position of the arguments in the expressions evaluation. These methods can also be called outside any container as variadic arguments of their respective type.