### PR TITLE
Easier default lexers customization

### DIFF
--- a/include/calculate/exception.hpp
+++ b/include/calculate/exception.hpp
@@ -15,6 +15,12 @@ struct BaseError : public std::runtime_error {
 };
 
 
+struct LexerError : BaseError {
+    explicit LexerError(const std::string& what) :
+            BaseError{"Lexer error: " + what}
+    {}
+};
+
 struct BadCast : BaseError {
     explicit BadCast(const std::string& token) :
             BaseError{
@@ -47,11 +53,11 @@ struct ArgumentsMismatch : BaseError {
 };
 
 struct EmptyExpression : BaseError {
-    EmptyExpression() : BaseError{"empty expression"} {}
+    EmptyExpression() : BaseError{"Empty expression"} {}
 };
 
 struct ParenthesisMismatch : BaseError {
-    ParenthesisMismatch() : BaseError{"parenthesis mismatch"} {}
+    ParenthesisMismatch() : BaseError{"Parenthesis mismatch"} {}
 };
 
 struct RepeatedSymbol : BaseError {

--- a/include/calculate/lexer.hpp
+++ b/include/calculate/lexer.hpp
@@ -191,7 +191,14 @@ public:
             default_separator(),
             default_decimal()
         }
-    ) : BaseLexer{regexes, strings} {}
+    ) : BaseLexer{regexes, strings} {
+        if (this->decimal != default_decimal())
+            throw LexerError{
+                "default lexer must use '" +
+                default_decimal() +
+                "' as decimal mark"
+            };
+    }
 
     std::shared_ptr<BaseLexer> clone() const noexcept override {
         return std::make_shared<Lexer>(*this);
@@ -236,7 +243,14 @@ public:
             default_separator(),
             default_decimal()
         }
-    ) : BaseLexer{regexes, strings} {}
+    ) : BaseLexer{regexes, strings} {
+        if (this->decimal != default_decimal())
+            throw LexerError{
+                "default lexer must use '" +
+                default_decimal() +
+                "' as decimal mark"
+            };
+    }
 
     std::shared_ptr<BaseLexer> clone() const noexcept override {
         return std::make_shared<Lexer>(*this);

--- a/include/calculate/lexer.hpp
+++ b/include/calculate/lexer.hpp
@@ -137,12 +137,30 @@ public:
             symbol_regex{symbol},
             tokenizer_regex{tokenizer}
     {
-        if ((left == right || left == separator || left == decimal) ||
-            (right == separator || right == decimal) ||
-            (separator == decimal)
+        enum Group {NUMBER=1, NAME, SYMBOL, LEFT, RIGHT, SEPARATOR, DECIMAL};
+        std::smatch match{};
+
+        if (left == right ||
+            left == separator ||
+            left == decimal ||
+            right == separator ||
+            right == decimal ||
+            separator == decimal
         )
             throw LexerError{"tokens must be different"};
 
+        std::regex_search(left, match, tokenizer_regex);
+        if (match[Group::LEFT].str().empty())
+            throw LexerError{"tokenizer doesn't match left symbol"};
+        std::regex_search(right, match, tokenizer_regex);
+        if (match[Group::RIGHT].str().empty())
+            throw LexerError{"tokenizer doesn't match right symbol"};
+        std::regex_search(separator, match, tokenizer_regex);
+        if (match[Group::SEPARATOR].str().empty())
+            throw LexerError{"tokenizer doesn't match separator symbol"};
+        std::regex_search(decimal, match, tokenizer_regex);
+        if (match[Group::DECIMAL].str().empty())
+            throw LexerError{"tokenizer doesn't match decimal symbol"};
     }
     BaseLexer(const BaseLexer&) = default;
     virtual ~BaseLexer() = default;

--- a/include/calculate/node.hpp
+++ b/include/calculate/node.hpp
@@ -5,6 +5,7 @@
 #include <ostream>
 #include <stack>
 #include <sstream>
+#include <unordered_set>
 
 #include "symbol.hpp"
 

--- a/include/calculate/parser.hpp
+++ b/include/calculate/parser.hpp
@@ -6,7 +6,6 @@
 #include <ostream>
 #include <queue>
 #include <string>
-#include <unordered_set>
 
 #include "lexer.hpp"
 #include "node.hpp"

--- a/include/calculate/symbol.hpp
+++ b/include/calculate/symbol.hpp
@@ -105,6 +105,7 @@ public:
     virtual std::unique_ptr<Symbol> clone() const noexcept = 0;
 };
 
+
 template<typename Expression>
 class Variable final : public Symbol<Expression> {
     using Symbol = calculate::Symbol<Expression>;


### PR DESCRIPTION
This pull request simplifies default lexers' constructors, autogenerating their tokenizer regexes and performing some sanity checks on the user input.

The performance loss due to the use of **stringstreams** for number conversions has also been fixed on this pull request.